### PR TITLE
Honor WARP_API_KEY for OSS GUI launches

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1090,10 +1090,16 @@ fn initialize_app(
         ctx.set_zoom_factor(WindowSettings::as_ref(ctx).zoom_level.as_zoom_factor());
     }
 
-    // Extract API key from command line options, if applicable.
+    // Extract API key from command line options, if applicable. Honored on the same
+    // channels as `WARP_SERVER_ROOT_URL` etc. (Dev/Local/Integration/Oss); Stable and
+    // Preview silently ignore it.
     let api_key = match launch_mode {
         LaunchMode::CommandLine { global_options, .. } => global_options.api_key.clone(),
-        LaunchMode::App { api_key, .. } if ChannelState::channel().is_dogfood() => api_key.clone(),
+        LaunchMode::App { api_key, .. }
+            if ChannelState::channel().allows_server_url_overrides() =>
+        {
+            api_key.clone()
+        }
         _ => None,
     };
     let api_key = if FeatureFlag::APIKeyAuthentication.is_enabled() {

--- a/crates/warp_core/src/channel/state_tests.rs
+++ b/crates/warp_core/src/channel/state_tests.rs
@@ -1,3 +1,5 @@
+use crate::channel::Channel;
+
 use super::derive_http_origin_from_ws_url;
 
 #[test]
@@ -16,4 +18,14 @@ fn ws_becomes_http_and_preserves_port() {
 fn unparseable_input_returns_none() {
     assert!(derive_http_origin_from_ws_url("not a url").is_none());
     assert!(derive_http_origin_from_ws_url("https://app.warp.dev").is_none());
+}
+
+#[test]
+fn allows_server_url_overrides_matches_api_key_app_launch_channels() {
+    assert!(Channel::Dev.allows_server_url_overrides());
+    assert!(Channel::Local.allows_server_url_overrides());
+    assert!(Channel::Integration.allows_server_url_overrides());
+    assert!(Channel::Oss.allows_server_url_overrides());
+    assert!(!Channel::Stable.allows_server_url_overrides());
+    assert!(!Channel::Preview.allows_server_url_overrides());
 }

--- a/docs/OSS_ALT_SERVER.md
+++ b/docs/OSS_ALT_SERVER.md
@@ -1,0 +1,61 @@
+# Pointing the OSS Warp build at an alternate server
+
+The `warp-oss` binary (`Channel::Oss`) ships with all the wiring needed to talk
+to a self-hosted, Warp-compatible alt server without any Firebase round-trip.
+Set two environment variables before launching:
+
+| Variable | Purpose |
+| -------- | ------- |
+| `WARP_SERVER_ROOT_URL` | Base URL of your alt server (e.g. `https://warp.alt.example`). Used for all REST + GraphQL requests. |
+| `WARP_API_KEY` | Opaque bearer token your alt server accepts. Sent as `Authorization: Bearer <token>` on every authenticated request. |
+
+Optional:
+
+| Variable | Purpose |
+| -------- | ------- |
+| `WARP_WS_SERVER_URL` | WebSocket endpoint for GraphQL subscriptions (e.g. Warp Drive realtime). Defaults are derived from `WARP_SERVER_ROOT_URL` if unset. |
+| `WARP_SESSION_SHARING_SERVER_URL` | Session-sharing WS endpoint (optional; leave unset to disable session sharing). |
+
+## Quick start
+
+```bash
+export WARP_SERVER_ROOT_URL="https://warp.alt.example"
+export WARP_API_KEY="<token-issued-by-your-alt-server>"
+warp-oss   # or `cargo run --bin warp-oss`
+```
+
+That's the entire integration on the client side. Internally:
+
+- `WARP_API_KEY` is consumed at startup in `app/src/lib.rs::run_internal()` and
+  seeds `Credentials::ApiKey` via `AuthState::initialize()`.
+- All authenticated requests go through `AuthClient::get_or_refresh_access_token()`
+  in `app/src/server/server_api/auth.rs`, which short-circuits the Firebase
+  refresh path for `Credentials::ApiKey` and returns `AuthToken::ApiKey(key)`
+  unchanged. No call to `securetoken.googleapis.com`.
+- The `SkipFirebaseAnonymousUser` feature flag (default-enabled on OSS) skips
+  the anonymous-user bootstrap mutation, so first-launch never round-trips
+  through Warp's hosted GraphQL either.
+
+## Channel scope
+
+`--api-key` / `WARP_API_KEY` is honored on every channel that already accepts
+server URL overrides (Dev, Local, Integration, OSS). Stable and Preview ignore
+both, so shipped first-party builds can't be redirected. See
+`Channel::allows_server_url_overrides` in `crates/warp_core/src/channel/mod.rs`.
+
+## Out of scope for this minimal recipe
+
+This document describes the bare minimum to point a single OSS build at a
+single alt server using a static long-lived bearer token. It deliberately does
+NOT cover:
+
+- Refresh-token flows / short-lived bearer credentials.
+- In-app login UI for alt servers (the existing API Keys widget can still be
+  used to paste a token at runtime).
+- Hiding hosted-billing UI surfaces (most are already gated on
+  `Channel::Oss` upstream; remaining surfaces will be addressed reactively).
+- Local context packaging (rules / MCP / Drive). Alt servers running on the
+  same machine can read the user's filesystem directly.
+
+These slices will be layered on only when a concrete user-facing gap is
+verified. See issues #14 and #15 for the broader pivot context.


### PR DESCRIPTION
## Summary

Single one-line predicate change so the OSS GUI build (`warp-oss`) actually honors `WARP_API_KEY` / `--api-key`. Together with the already-default-enabled `APIKeyAuthentication` and `SkipFirebaseAnonymousUser` feature flags, this is the entire client-side change needed to point an OSS build at a Warp-compatible alt server using a static bearer token. No new credentials, no new env vars, no new feature flags, no UI changes.

Refs: #14, #15

## What was broken

`Credentials::ApiKey` already bypasses Firebase end-to-end (`app/src/server/server_api/auth.rs:253` returns `AuthToken::ApiKey` directly), and `WARP_API_KEY` is fully wired through `crates/warp_cli/src/lib.rs:77` into `AuthState::initialize` (`app/src/auth/auth_state.rs:82–104`). But the gate at `app/src/lib.rs::initialize_app`:

```rust
LaunchMode::App { api_key, .. } if ChannelState::channel().is_dogfood() => api_key.clone(),
```

silently dropped the key for any non-dogfood channel — including `Channel::Oss`. CLI invocations work (no channel guard on the `LaunchMode::CommandLine` arm); the GUI did not.

## The fix

Widen the gate from `is_dogfood()` to `allows_server_url_overrides()`, the existing `Channel` predicate that already gates the matching `WARP_SERVER_ROOT_URL` / `WARP_WS_SERVER_URL` / `WARP_SESSION_SHARING_SERVER_URL` overrides ~500 lines above in the same file. It returns `true` for `Dev`, `Local`, `Integration`, `Oss` and `false` for `Stable`, `Preview` — exactly the channel set we want.

## Diff

```
app/src/lib.rs                              | 10 ++++++++--
crates/warp_core/src/channel/state_tests.rs | 12 ++++++++++++
docs/OSS_ALT_SERVER.md                      | 61 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
3 files changed, 81 insertions(+), 2 deletions(-)
```

- `app/src/lib.rs`: 1-line predicate change + 3-line rationale comment.
- `crates/warp_core/src/channel/state_tests.rs`: append-only test locking in which channels honor (and don't honor) the gate. If anyone in the future narrows `allows_server_url_overrides()`, this fails and signals that `lib.rs` also needs review.
- `docs/OSS_ALT_SERVER.md`: operator recipe.

## Why it's fork-friendly

Designed for minimum upstream merge friction — this fork tracks `warpdotdev/warp` and we don't want a separate hard fork:

- Touches one upstream-owned file (`lib.rs`) with a 1-line semantic change. The remaining additions are append-only (`state_tests.rs`) or new files (`docs/`).
- No new credential variants, no new traits/abstraction layers, no new feature flags, no new env vars.
- Follows upstream's existing `Channel`-predicate convention; the predicate `allows_server_url_overrides()` already exists and is already used for the analogous URL-override path.

## Verification

Locally:

```
cargo fmt --all -- --check                                       # ✅
cargo clippy -p warp -p warp_core --all-targets -- -D warnings   # ✅
cargo nextest run -p warp_core                                    # ✅ 44/44
```

Plus the new `allows_server_url_overrides_matches_api_key_app_launch_channels` test passes.

## Quick start (for reviewers)

```bash
export WARP_SERVER_ROOT_URL="https://warp.alt.example"
export WARP_API_KEY="<token>"
warp-oss
```

`Credentials::ApiKey` is set at startup; every authenticated request goes out as `Authorization: Bearer <token>`; no Firebase round-trip.

## Out of scope (deferred / probably unnecessary)

The full plan in #14 covered refresh tokens, anonymous-bootstrap replacement, an endpoint settings widget, hosted-billing UI hides, local context packaging, and typed diagnostics. All of those are deferred and most are likely unnecessary — see [my comment on #14](https://github.com/nikhil-pandey/warp/issues/14#issuecomment-4349722696) for the full audit. Layer them on reactively only when a concrete user-facing gap is verified.
